### PR TITLE
URL Cleanup

### DIFF
--- a/README
+++ b/README
@@ -1,12 +1,12 @@
 MochiWeb is an Erlang library for building lightweight HTTP servers.
 
-The latest version of MochiWeb is available at http://github.com/mochi/mochiweb
+The latest version of MochiWeb is available at https://github.com/mochi/mochiweb
 
-The mailing list for MochiWeb is at http://groups.google.com/group/mochiweb/
+The mailing list for MochiWeb is at https://groups.google.com/group/mochiweb/
 
 R12B compatibility:
 The master of MochiWeb is tested with R14A and later. A branch compatible
-with R12B is maintained separately at http://github.com/lemenkov/mochiweb
+with R12B is maintained separately at https://github.com/lemenkov/mochiweb
 The R12B branch of that repository is mirrored in the official repository
 occasionally for convenience.
 

--- a/examples/hmac_api/README
+++ b/examples/hmac_api/README
@@ -145,7 +145,7 @@ The Reference Implementation In This Example
 --------------------------------------------
 
 The reference implementation used in this example is that described in the Amazon documentation here:
-http://docs.amazonwebservices.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html
+https://docs.aws.amazon.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html
 
 The try out the reference implementation:
 * create a new mochiweb project as per the mochiweb README

--- a/examples/hmac_api/hmac_api.hrl
+++ b/examples/hmac_api/hmac_api.hrl
@@ -26,7 +26,7 @@
 
 %% a couple of keys for testing
 %% these are taken from the document
-%% % http://docs.amazonwebservices.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html
+%% % https://docs.aws.amazon.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html
 %% they are not valid keys!
 -define(publickey,  "0PN5J17HBGZHT7JJ3X82").
 -define(privatekey, "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o").

--- a/examples/hmac_api/hmac_api_client.erl
+++ b/examples/hmac_api/hmac_api_client.erl
@@ -18,7 +18,7 @@ fire() ->
     %% Dates can be conveniently generated using dh_date.erl
     %% https://github.com/daleharvey/dh_date
     %% which is largely compatible with
-    %% http://uk.php.net/date
+    %% http://uk3.php.net/manual/en/function.date.php
 
     %% You MIGHT find it convenient to insist on times in UTC only
     %% as it reduces the errors caused by summer time and other

--- a/examples/hmac_api/hmac_api_lib.erl
+++ b/examples/hmac_api/hmac_api_lib.erl
@@ -190,7 +190,7 @@ get_header(Headers, Type) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
                                                 % taken from Amazon docs
-%% http://docs.amazonwebservices.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html
+%% https://docs.aws.amazon.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html
 hash_test1(_) ->
     Sig = "DELETE\n\n\n\nx-amz-date:Tue, 27 Mar 2007 21:20:26 +0000\n/johnsmith/photos/puppy.jpg",
     Key = ?privatekey,
@@ -199,7 +199,7 @@ hash_test1(_) ->
     ?assertEqual(Expected, Hash).
 
 %% taken from Amazon docs
-%% http://docs.amazonwebservices.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html
+%% https://docs.aws.amazon.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html
 hash_test2(_) ->
     Sig = "GET\n\n\nTue, 27 Mar 2007 19:44:46 +0000\n/johnsmith/?acl",
     Key = "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o",
@@ -208,7 +208,7 @@ hash_test2(_) ->
     ?assertEqual(Expected, Hash).
 
 %% taken from Amazon docs
-%% http://docs.amazonwebservices.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html
+%% https://docs.aws.amazon.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html
 hash_test3(_) ->
     Sig = "GET\n\n\nWed, 28 Mar 2007 01:49:49 +0000\n/dictionary/"
         ++ "fran%C3%A7ais/pr%c3%a9f%c3%a8re",
@@ -218,7 +218,7 @@ hash_test3(_) ->
     ?assertEqual(Expected, Hash).
 
 signature_test1(_) ->
-    URL = "http://example.com:90/tongs/ya/bas",
+    URL = "https://example.com:90/tongs/ya/bas",
     Method = post,
     ContentMD5 = "",
     ContentType = "",
@@ -235,7 +235,7 @@ signature_test1(_) ->
     ?assertEqual(Expected, Sig).
 
 signature_test2(_) ->
-    URL = "http://example.com:90/tongs/ya/bas",
+    URL = "https://example.com:90/tongs/ya/bas",
     Method = get,
     ContentMD5 = "",
     ContentType = "",
@@ -252,7 +252,7 @@ signature_test2(_) ->
     ?assertEqual(Expected, Sig).
 
 signature_test3(_) ->
-    URL = "http://example.com:90/tongs/ya/bas",
+    URL = "https://example.com:90/tongs/ya/bas",
     Method = get,
     ContentMD5 = "",
     ContentType = "",
@@ -272,7 +272,7 @@ signature_test3(_) ->
     ?assertEqual(Expected, Sig).
 
 signature_test4(_) ->
-    URL = "http://example.com:90/tongs/ya/bas",
+    URL = "https://example.com:90/tongs/ya/bas",
     Method = get,
     ContentMD5 = "",
     ContentType = "",
@@ -292,7 +292,7 @@ signature_test4(_) ->
     ?assertEqual(Expected, Sig).
 
 signature_test5(_) ->
-    URL = "http://example.com:90/tongs/ya/bas",
+    URL = "https://example.com:90/tongs/ya/bas",
     Method = get,
     ContentMD5 = "",
     ContentType = "",
@@ -312,7 +312,7 @@ signature_test5(_) ->
     ?assertEqual(Expected, Sig).
 
 signature_test6(_) ->
-    URL = "http://example.com:90/tongs/ya/bas/?andy&zbish=bash&bosh=burp",
+    URL = "https://example.com:90/tongs/ya/bas/?andy&zbish=bash&bosh=burp",
     Method = get,
     ContentMD5 = "",
     ContentType = "",
@@ -330,7 +330,7 @@ signature_test6(_) ->
     ?assertEqual(Expected, Sig).
 
 signature_test7(_) ->
-    URL = "http://exAMPLE.Com:90/tONgs/ya/bas/?ANdy&ZBish=Bash&bOsh=burp",
+    URL = "https://exAMPLE.Com:90/tONgs/ya/bas/?ANdy&ZBish=Bash&bOsh=burp",
     Method = get,
     ContentMD5 = "",
     ContentType = "",
@@ -348,7 +348,7 @@ signature_test7(_) ->
     ?assertEqual(Expected, Sig).
 
 signature_test8(_) ->
-    URL = "http://exAMPLE.Com:90/tONgs/ya/bas/?ANdy&ZBish=Bash&bOsh=burp",
+    URL = "https://exAMPLE.Com:90/tONgs/ya/bas/?ANdy&ZBish=Bash&bOsh=burp",
     Method = get,
     ContentMD5 = "",
     ContentType = "",
@@ -367,7 +367,7 @@ signature_test8(_) ->
     ?assertEqual(Expected, Sig).
 
 signature_test9(_) ->
-    URL = "http://exAMPLE.Com:90/tONgs/ya/bas/?ANdy&ZBish=Bash&bOsh=burp",
+    URL = "https://exAMPLE.Com:90/tONgs/ya/bas/?ANdy&ZBish=Bash&bOsh=burp",
     Method = get,
     ContentMD5 = "",
     ContentType = "",
@@ -386,7 +386,7 @@ signature_test9(_) ->
     ?assertEqual(Expected, Sig).
 
 amazon_test1(_) ->
-    URL = "http://exAMPLE.Com:90/johnsmith/photos/puppy.jpg",
+    URL = "https://exAMPLE.Com:90/johnsmith/photos/puppy.jpg",
     Method = delete,
     ContentMD5 = "",
     ContentType = "",

--- a/examples/keepalive/keepalive.erl
+++ b/examples/keepalive/keepalive.erl
@@ -3,7 +3,7 @@
 %% your web app can push data to clients using a technique called comet long
 %% polling.  browsers make a request and your server waits to send a
 %% response until data is available.  see wikipedia for a better explanation:
-%% http://en.wikipedia.org/wiki/Comet_(programming)#Ajax_with_long_polling
+%% https://en.wikipedia.org/wiki/Comet_(programming)#Ajax_with_long_polling
 %%
 %% since the majority of your http handlers will be idle at any given moment,
 %% you might consider making them hibernate while they wait for more data from

--- a/scripts/entities.erl
+++ b/scripts/entities.erl
@@ -7,7 +7,7 @@
 main(_) ->
     application:start(inets),
     code:add_patha("ebin"),
-    {ok, {_, _, HTML}} = httpc:request("http://www.w3.org/TR/html5/named-character-references.html"),
+    {ok, {_, _, HTML}} = httpc:request("https://www.w3.org/TR/html5/named-character-references.html"),
     print(lists:sort(search(mochiweb_html:parse(HTML)))).
 
 print([F | T]) ->

--- a/src/mochifmt.erl
+++ b/src/mochifmt.erl
@@ -2,7 +2,7 @@
 %% @copyright 2008 Mochi Media, Inc.
 
 %% @doc String Formatting for Erlang, inspired by Python 2.6
-%%      (<a href="http://www.python.org/dev/peps/pep-3101/">PEP 3101</a>).
+%%      (<a href="https://www.python.org/dev/peps/pep-3101/">PEP 3101</a>).
 %%
 -module(mochifmt).
 -author('bob@mochimedia.com').

--- a/src/mochijson.erl
+++ b/src/mochijson.erl
@@ -466,7 +466,7 @@ e2j_vec_test() ->
     test_one(e2j_test_vec(utf8), 1).
 
 issue33_test() ->
-    %% http://code.google.com/p/mochiweb/issues/detail?id=33
+    %% https://code.google.com/p/mochiweb/issues/detail?id=33
     Js = {struct, [{"key", [194, 163]}]},
     Encoder = encoder([{input_encoding, utf8}]),
     "{\"key\":\"\\u00a3\"}" = lists:flatten(Encoder(Js)).

--- a/src/mochiweb.erl
+++ b/src/mochiweb.erl
@@ -50,7 +50,7 @@ new_request({Socket, {Method, {absoluteURI, _Protocol, _Host, _Port, Uri},
                          Version,
                          mochiweb_headers:make(Headers));
 %% Request-URI is "*"
-%% From http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2
+%% From https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2
 new_request({Socket, {Method, '*'=Uri, Version}, Headers}) ->
     mochiweb_request:new(Socket,
                          Method,

--- a/src/mochiweb_charref.erl
+++ b/src/mochiweb_charref.erl
@@ -30,7 +30,7 @@ charref(L) ->
 %% Internal API.
 
 %% [2011-10-14] Generated from:
-%% http://www.w3.org/TR/html5/named-character-references.html
+%% https://www.w3.org/TR/html5/named-character-references.html
 
 entity("AElig") -> 16#000C6;
 entity("AMP") -> 16#00026;

--- a/src/mochiweb_html.erl
+++ b/src/mochiweb_html.erl
@@ -553,7 +553,7 @@ tokenize_literal(Bin, S=#decoder{offset=O}) ->
                                     orelse C =:= $/
                                     orelse C =:= $= ->
             %% Handle case where tokenize_literal would consume
-            %% 0 chars. http://github.com/mochi/mochiweb/pull/13
+            %% 0 chars. https://github.com/mochi/mochiweb/pull/13
             {[C], ?INC_COL(S)};
         _ ->
             tokenize_literal(Bin, S, [])

--- a/src/mochiweb_multipart.erl
+++ b/src/mochiweb_multipart.erl
@@ -177,7 +177,7 @@ read_more(State=#mp{length=Length, buffer=Buffer, req=Req}) ->
                                   buffer=Buffer1}).
 
 flash_multipart_hack(State=#mp{length=0, buffer=Buffer, boundary=Prefix}) ->
-    %% http://code.google.com/p/mochiweb/issues/detail?id=22
+    %% https://code.google.com/p/mochiweb/issues/detail?id=22
     %% Flash doesn't terminate multipart with \r\n properly so we fix it up here
     PrefixSize = size(Prefix),
     case size(Buffer) - (2 + PrefixSize) of

--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -315,7 +315,7 @@ respond({Code, ResponseHeaders, chunked}, {?MODULE, [_Socket, Method, _RawPath, 
     HResponse = mochiweb_headers:make(ResponseHeaders),
     HResponse1 = case Method of
                      'HEAD' ->
-                         %% This is what Google does, http://www.google.com/
+                         %% This is what Google does, https://www.google.com/
                          %% is chunked but HEAD gets Content-Length: 0.
                          %% The RFC is ambiguous so emulating Google is smart.
                          mochiweb_headers:enter("Content-Length", "0",
@@ -364,7 +364,7 @@ ok({ContentType, ResponseHeaders, Body}, {?MODULE, [_Socket, _Method, _RawPath, 
     HResponse = mochiweb_headers:make(ResponseHeaders),
     case THIS:get(range) of
         X when (X =:= undefined orelse X =:= fail) orelse Body =:= chunked ->
-            %% http://code.google.com/p/mochiweb/issues/detail?id=54
+            %% https://code.google.com/p/mochiweb/issues/detail?id=54
             %% Range header not supported when chunked, return 200 and provide
             %% full response.
             HResponse1 = mochiweb_headers:enter("Content-Type", ContentType,

--- a/src/mochiweb_session.erl
+++ b/src/mochiweb_session.erl
@@ -4,7 +4,7 @@
 %% as far as this module is concerned. In order to achieve more security,
 %% it is advised to use https.
 %% Based on the paper
-%% <a href="http://www.cse.msu.edu/~alexliu/publications/Cookie/cookie.pdf">
+%% <a href="https://www.cse.msu.edu/~alexliu/publications/Cookie/cookie.pdf">
 %% "A Secure Cookie Protocol"</a>.
 %% This module is only supported on R15B02 and later, the AES CFB mode is not
 %% available in earlier releases of crypto.

--- a/src/mochiweb_util.erl
+++ b/src/mochiweb_util.erl
@@ -709,8 +709,8 @@ path_split_test() ->
 urlsplit_test() ->
     {"", "", "/foo", "", "bar?baz"} = urlsplit("/foo#bar?baz"),
     {"http", "host:port", "/foo", "", "bar?baz"} =
-        urlsplit("http://host:port/foo#bar?baz"),
-    {"http", "host", "", "", ""} = urlsplit("http://host"),
+        urlsplit("https://host:port/foo#bar?baz"),
+    {"http", "host", "", "", ""} = urlsplit("https://host"),
     {"", "", "/wiki/Category:Fruit", "", ""} =
         urlsplit("/wiki/Category:Fruit"),
     ok.
@@ -726,7 +726,7 @@ urlsplit_path_test() ->
 
 urlunsplit_test() ->
     "/foo#bar?baz" = urlunsplit({"", "", "/foo", "", "bar?baz"}),
-    "http://host:port/foo#bar?baz" =
+    "https://host:port/foo#bar?baz" =
         urlunsplit({"http", "host:port", "/foo", "", "bar?baz"}),
     ok.
 

--- a/test/mochiweb_html_tests.erl
+++ b/test/mochiweb_html_tests.erl
@@ -14,12 +14,12 @@ to_html_test() ->
                      {'=', <<"RAW!">>},
                      {comment, <<" comment! ">>}]}]}))),
     ?assertEqual(
-       <<"<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">">>,
+       <<"<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">">>,
        iolist_to_binary(
          mochiweb_html:to_html({doctype,
                   [<<"html">>, <<"PUBLIC">>,
                    <<"-//W3C//DTD XHTML 1.0 Transitional//EN">>,
-                   <<"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">>]}))),
+                   <<"https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">>]}))),
     ?assertEqual(
        <<"<html><?xml:namespace prefix=\"o\" ns=\"urn:schemas-microsoft-com:office:office\"?></html>">>,
        iolist_to_binary(
@@ -127,7 +127,7 @@ tokens_test() ->
     ok.
 
 parse_test() ->
-    D0 = <<"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">
+    D0 = <<"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"https://www.w3.org/TR/html4/strict.dtd\">
 <html>
  <head>
    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">
@@ -233,14 +233,14 @@ tokenize_attributes_test() ->
     ok.
 
 tokens2_test() ->
-    D0 = <<"<channel><title>from __future__ import *</title><link>http://bob.pythonmac.org</link><description>Bob's Rants</description></channel>">>,
+    D0 = <<"<channel><title>from __future__ import *</title><link>https://bob.ippoli.to/</link><description>Bob's Rants</description></channel>">>,
     ?assertEqual(
        [{start_tag,<<"channel">>,[],false},
         {start_tag,<<"title">>,[],false},
         {data,<<"from __future__ import *">>,false},
         {end_tag,<<"title">>},
         {start_tag,<<"link">>,[],true},
-        {data,<<"http://bob.pythonmac.org">>,false},
+        {data,<<"https://bob.ippoli.to/">>,false},
         {end_tag,<<"link">>},
         {start_tag,<<"description">>,[],false},
         {data,<<"Bob's Rants">>,false},
@@ -277,12 +277,12 @@ to_tokens_test() ->
     ok.
 
 parse2_test() ->
-    D0 = <<"<channel><title>from __future__ import *</title><link>http://bob.pythonmac.org<br>foo</link><description>Bob's Rants</description></channel>">>,
+    D0 = <<"<channel><title>from __future__ import *</title><link>https://bob.ippoli.to/<br>foo</link><description>Bob's Rants</description></channel>">>,
     ?assertEqual(
        {<<"channel">>,[],
         [{<<"title">>,[],[<<"from __future__ import *">>]},
          {<<"link">>,[],[
-                         <<"http://bob.pythonmac.org">>,
+                         <<"https://bob.ippoli.to/">>,
                          {<<"br">>,[],[]},
                          <<"foo">>]},
          {<<"description">>,[],[<<"Bob's Rants">>]}]},
@@ -391,15 +391,15 @@ destack_test() ->
 doctype_test() ->
     ?assertEqual(
        {<<"html">>,[],[{<<"head">>,[],[]}]},
-       mochiweb_html:parse("<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">"
+       mochiweb_html:parse("<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"https://www.w3.org/TR/html4/loose.dtd\">"
                            "<html><head></head></body></html>")),
-    %% http://code.google.com/p/mochiweb/issues/detail?id=52
+    %% https://code.google.com/p/mochiweb/issues/detail?id=52
     ?assertEqual(
        {<<"html">>,[],[{<<"head">>,[],[]}]},
        mochiweb_html:parse("<html>"
-                           "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">"
+                           "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"https://www.w3.org/TR/html4/loose.dtd\">"
                            "<head></head></body></html>")),
-    %% http://github.com/mochi/mochiweb/pull/13
+    %% https://github.com/mochi/mochiweb/pull/13
     ?assertEqual(
        {<<"html">>,[],[{<<"head">>,[],[]}]},
        mochiweb_html:parse("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0 Transitional//EN\"/>"
@@ -408,7 +408,7 @@ doctype_test() ->
     ok.
 
 dumb_br_test() ->
-    %% http://code.google.com/p/mochiweb/issues/detail?id=71
+    %% https://code.google.com/p/mochiweb/issues/detail?id=71
     ?assertEqual(
        {<<"div">>,[],[{<<"br">>, [], []}, {<<"br">>, [], []}, <<"z">>]},
        mochiweb_html:parse("<div><br/><br/>z</br/></br/></div>")),
@@ -424,7 +424,7 @@ dumb_br_test() ->
 
 
 php_test() ->
-    %% http://code.google.com/p/mochiweb/issues/detail?id=71
+    %% https://code.google.com/p/mochiweb/issues/detail?id=71
     ?assertEqual(
        [{pi, <<"php\n">>}],
        mochiweb_html:tokens(


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://uk.php.net/date (301) with 1 occurrences could not be migrated:  
   ([https](https://uk.php.net/date) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://exAMPLE.Com:90/johnsmith/photos/puppy.jpg (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://exAMPLE.Com:90/johnsmith/photos/puppy.jpg ([https](https://exAMPLE.Com:90/johnsmith/photos/puppy.jpg) result ConnectTimeoutException).
* http://exAMPLE.Com:90/tONgs/ya/bas/?ANdy&ZBish=Bash&bOsh=burp (ConnectTimeoutException) with 3 occurrences migrated to:  
  https://exAMPLE.Com:90/tONgs/ya/bas/?ANdy&ZBish=Bash&bOsh=burp ([https](https://exAMPLE.Com:90/tONgs/ya/bas/?ANdy&ZBish=Bash&bOsh=burp) result ConnectTimeoutException).
* http://example.com:90/tongs/ya/bas (ConnectTimeoutException) with 5 occurrences migrated to:  
  https://example.com:90/tongs/ya/bas ([https](https://example.com:90/tongs/ya/bas) result ConnectTimeoutException).
* http://example.com:90/tongs/ya/bas/?andy&zbish=bash&bosh=burp (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://example.com:90/tongs/ya/bas/?andy&zbish=bash&bosh=burp ([https](https://example.com:90/tongs/ya/bas/?andy&zbish=bash&bosh=burp) result ConnectTimeoutException).
* http://www.w3.org/TR/html4/loose.dtd (ReadTimeoutException) with 2 occurrences migrated to:  
  https://www.w3.org/TR/html4/loose.dtd ([https](https://www.w3.org/TR/html4/loose.dtd) result ReadTimeoutException).
* http://www.w3.org/TR/html4/strict.dtd (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/html4/strict.dtd ([https](https://www.w3.org/TR/html4/strict.dtd) result ReadTimeoutException).
* http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd (ReadTimeoutException) with 2 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd) result ReadTimeoutException).
* http://host (UnknownHostException) with 1 occurrences migrated to:  
  https://host ([https](https://host) result UnknownHostException).
* http://host:port/foo (UnknownHostException) with 2 occurrences migrated to:  
  https://host:port/foo ([https](https://host:port/foo) result UnknownHostException).
* http://www.w3.org/TR/html5/named-character-references.html (404) with 2 occurrences migrated to:  
  https://www.w3.org/TR/html5/named-character-references.html ([https](https://www.w3.org/TR/html5/named-character-references.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://bob.pythonmac.org (301) with 4 occurrences migrated to:  
  https://bob.ippoli.to/ ([https](https://bob.pythonmac.org) result 200).
* http://docs.amazonwebservices.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html (301) with 5 occurrences migrated to:  
  https://docs.aws.amazon.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html ([https](https://docs.amazonwebservices.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html) result 200).
* http://github.com/lemenkov/mochiweb with 1 occurrences migrated to:  
  https://github.com/lemenkov/mochiweb ([https](https://github.com/lemenkov/mochiweb) result 200).
* http://github.com/mochi/mochiweb with 1 occurrences migrated to:  
  https://github.com/mochi/mochiweb ([https](https://github.com/mochi/mochiweb) result 200).
* http://github.com/mochi/mochiweb/pull/13 with 2 occurrences migrated to:  
  https://github.com/mochi/mochiweb/pull/13 ([https](https://github.com/mochi/mochiweb/pull/13) result 200).
* http://www.cse.msu.edu/~alexliu/publications/Cookie/cookie.pdf with 1 occurrences migrated to:  
  https://www.cse.msu.edu/~alexliu/publications/Cookie/cookie.pdf ([https](https://www.cse.msu.edu/~alexliu/publications/Cookie/cookie.pdf) result 200).
* http://www.google.com/ with 1 occurrences migrated to:  
  https://www.google.com/ ([https](https://www.google.com/) result 200).
* http://www.python.org/dev/peps/pep-3101/ with 1 occurrences migrated to:  
  https://www.python.org/dev/peps/pep-3101/ ([https](https://www.python.org/dev/peps/pep-3101/) result 200).
* http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html with 1 occurrences migrated to:  
  https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html ([https](https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html) result 200).
* http://code.google.com/p/mochiweb/issues/detail?id=22 with 1 occurrences migrated to:  
  https://code.google.com/p/mochiweb/issues/detail?id=22 ([https](https://code.google.com/p/mochiweb/issues/detail?id=22) result 301).
* http://code.google.com/p/mochiweb/issues/detail?id=33 with 1 occurrences migrated to:  
  https://code.google.com/p/mochiweb/issues/detail?id=33 ([https](https://code.google.com/p/mochiweb/issues/detail?id=33) result 301).
* http://code.google.com/p/mochiweb/issues/detail?id=52 with 1 occurrences migrated to:  
  https://code.google.com/p/mochiweb/issues/detail?id=52 ([https](https://code.google.com/p/mochiweb/issues/detail?id=52) result 301).
* http://code.google.com/p/mochiweb/issues/detail?id=54 with 1 occurrences migrated to:  
  https://code.google.com/p/mochiweb/issues/detail?id=54 ([https](https://code.google.com/p/mochiweb/issues/detail?id=54) result 301).
* http://code.google.com/p/mochiweb/issues/detail?id=71 with 2 occurrences migrated to:  
  https://code.google.com/p/mochiweb/issues/detail?id=71 ([https](https://code.google.com/p/mochiweb/issues/detail?id=71) result 301).
* http://en.wikipedia.org/wiki/Comet_ with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Comet_ ([https](https://en.wikipedia.org/wiki/Comet_) result 301).
* http://groups.google.com/group/mochiweb/ with 1 occurrences migrated to:  
  https://groups.google.com/group/mochiweb/ ([https](https://groups.google.com/group/mochiweb/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1 with 1 occurrences
* http://127.0.0.1:8080/some/page/yeah/ with 1 occurrences